### PR TITLE
removed snyk-protect

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,7 @@
     "test-client-ie": "./node_modules/.bin/karma start --single-run --browsers IE",
     "test-local": "npm run-script pretest && npm run-script test-client-chrome && npm run-script test-client-ie && npm run-script test-client-phantomjs && npm run-script test-client-firefox",
     "citest": "./node_modules/.bin/karma start --single-run false --browsers Chrome",
-    "codecov": "./node_modules/.bin/codecov",
-    "snyk-protect": "snyk protect",
-    "prepublish": "npm run snyk-protect"
+    "codecov": "./node_modules/.bin/codecov"
   },
   "description": "OWASP Threat Dragon core module",
   "author": {


### PR DESCRIPTION
This is erroring when publishing the package:

Snyk couldn't patch the specified vulnerabilities because GNU's patch is not available. Please install 'patch' and try again.