### PR TITLE
replaced rule engine

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -17,6 +17,7 @@ module.exports = function (config) {
 
     // list of files / patterns to load in the browser
     files: [
+      { pattern: 'node_modules/babel-polyfill/browser.js', instrument: false},
       'test/spec/*.js'
     ],
 

--- a/package.json
+++ b/package.json
@@ -36,13 +36,14 @@
     "bootstrap": "3.4.1",
     "jointjs": "2.2.1",
     "jquery": "3.3.1",
+    "json-rules-engine": "3.0.2",
     "lodash": "4.17.11",
-    "nools": "0.4.4",
-    "toastr": "2.1.2",
-    "snyk": "^1.52.0"
+    "snyk": "^1.52.0",
+    "toastr": "2.1.2"
   },
   "devDependencies": {
     "angular-mocks": "1.7.8",
+    "babel-polyfill": "6.26.0",
     "browserify": "14.5.0",
     "browserify-css": "0.13.1",
     "browserify-istanbul": "3.0.1",

--- a/src/services/threatengine.js
+++ b/src/services/threatengine.js
@@ -1,19 +1,13 @@
 ﻿'use strict';
 
-var nools = require('nools');
+var Engine = require('json-rules-engine').Engine;
 
 function threatengine() {
-
-    var flowName = 'threat generation';
 
     var service = {
         generateForElement: generateForElement,
         generateForElementInContext: generateForElementInContext,
         generateForGraph: generateForGraph
-    };
-
-    var Threats = function () {
-        this.collection = [];
     };
 
     var Element = function (element) {
@@ -24,16 +18,19 @@ function threatengine() {
 
     function generateForElement(element) {
         //todo: implement proper rule set
+        var engine = new Engine();
+        initialiseRules(engine);
+        engine.addFact('el', new Element(element));
 
-        var flow = initialiseFlow(flowName);
-        var threats = new Threats();
-        var el = new Element(element);
-        var session = flow.getSession(threats, el);
-        return session.match().then(function () {
-            session.dispose();
-            nools.deleteFlow(flowName);
-            return threats.collection;
-        });
+        return engine.run().then(onCompleted);
+
+        function onCompleted(results) {
+            //output is like {type: ..., params: { param1: ..., param2: ...}}
+            //use params to represent the threat to preserve backward compatibility
+            return results.map(function(result) {
+                return result.params;
+            });
+        }
     }
 
     function generateForElementInContext() {
@@ -46,77 +43,214 @@ function threatengine() {
         return [];
     }
 
-    function initialiseFlow(flowName) {
-        return nools.flow(flowName, function (flow) {
+    function initialiseRules(engine) {
 
-            flow.rule('Generic Spoofing Threat Rule', [
-                ['or',
-                    [Element, 'el', 'el.element.attributes.type == "tm.Process"'],
-                    [Element, 'el', 'el.element.attributes.type == "tm.Actor"']
-                ],
-                [Threats, 'threats']
-            ], function (facts) {
-                facts.threats.collection.push({ ruleId: 'b2a6d40d-d3f8-4750-8e4d-c02cc84b13dc', title: 'Generic spoofing threat', type: 'Spoofing', status: 'Open', severity: 'Medium', description: 'A generic spoofing threat' });
-            });
+        engine.addRule({
+            conditions: {
+                any: [{
+                    fact: 'el',
+                    path: '.element.attributes.type',
+                    operator: 'equal',
+                    value: 'tm.Process'
+                }, {
+                    fact: 'el',
+                    path: '.element.attributes.type',
+                    operator: 'equal',
+                    value: 'tm.Actor'                        
+                }]
+            },
+            event: {
+                type: 'b2a6d40d-d3f8-4750-8e4d-c02cc84b13dc',
+                params: {
+                    ruleId: 'b2a6d40d-d3f8-4750-8e4d-c02cc84b13dc',
+                    title: 'Generic spoofing threat',
+                    type: 'Spoofing',
+                    status: 'Open',
+                    severity: 'Medium',
+                    description: 'A generic spoofing threat'
+                }
+            }
+        });
 
-            flow.rule('Generic Tampering Threat Rule', [
-                ['or',
-                    [Element, 'el', 'el.element.attributes.type == "tm.Process"'],
-                    [Element, 'el', 'el.element.attributes.type == "tm.Store"'],
-                    [Element, 'el', 'el.element.attributes.type == "tm.Flow"']
-                ],
-                [Threats, 'threats']
-            ], function (facts) {
-                facts.threats.collection.push({ ruleId: '4adaa48a-0345-4533-a189-64c98c4420dd', title: 'Generic tampering threat', type: 'Tampering', status: 'Open', severity: 'Medium', description: 'A generic tampering threat' });
-            });
+        engine.addRule({
+            conditions: {
+                any: [{
+                    fact: 'el',
+                    path: '.element.attributes.type',
+                    operator: 'equal',
+                    value: 'tm.Process'
+                }, {
+                    fact: 'el',
+                    path: '.element.attributes.type',
+                    operator: 'equal',
+                    value: 'tm.Store'                        
+                } , {
+                    fact: 'el',
+                    path: '.element.attributes.type',
+                    operator: 'equal',
+                    value: 'tm.Flow'                        
+                }]
+            },
+            event: {
+                type: '4adaa48a-0345-4533-a189-64c98c4420dd',
+                params: {
+                    ruleId: '4adaa48a-0345-4533-a189-64c98c4420dd',
+                    title: 'Generic tampering threat',
+                    type: 'Tampering',
+                    status: 'Open',
+                    severity: 'Medium',
+                    description: 'A generic tampering threat'
+                }
+            }
+        });
 
-            flow.rule('Generic Repudiation Threat Rule', [
-                ['or',
-                    [Element, 'el', 'el.element.attributes.type == "tm.Process"'],
-                    [Element, 'el', 'el.element.attributes.type == "tm.Store"'],
-                    [Element, 'el', 'el.element.attributes.type == "tm.Actor"']
-                ],
-                [Threats, 'threats']
-            ], function (facts) {
-                facts.threats.collection.push({ ruleId: '87bc37e2-798e-4d68-bb96-feb1da26da48', title: 'Generic repudiation threat', type: 'Repudiation', status: 'Open', severity: 'Medium', description: 'A generic repudiation threat' });
-            });
+        engine.addRule({
+            conditions: {
+                any: [{
+                    fact: 'el',
+                    path: '.element.attributes.type',
+                    operator: 'equal',
+                    value: 'tm.Process'
+                }, {
+                    fact: 'el',
+                    path: '.element.attributes.type',
+                    operator: 'equal',
+                    value: 'tm.Store'                        
+                } , {
+                    fact: 'el',
+                    path: '.element.attributes.type',
+                    operator: 'equal',
+                    value: 'tm.Actor'                        
+                }]
+            },
+            event: {
+                type: '87bc37e2-798e-4d68-bb96-feb1da26da48',
+                params: {
+                    ruleId: '87bc37e2-798e-4d68-bb96-feb1da26da48',
+                    title: 'Generic repudiation threat',
+                    type: 'Repudiation',
+                    status: 'Open',
+                    severity: 'Medium',
+                    description: 'A generic repudiation threat'
+                }
+            }
+        });
 
-            flow.rule('Generic Information Disclosure Threat Rule', [
-                ['or',
-                    [Element, 'el', 'el.element.attributes.type == "tm.Process"'],
-                    [Element, 'el', 'el.element.attributes.type == "tm.Store"'],
-                    [Element, 'el', 'el.element.attributes.type == "tm.Flow"']
-                ],
-                [Threats, 'threats']
-            ], function (facts) {
-                facts.threats.collection.push({ ruleId: '13000296-b17d-4b72-9cc4-f5cc33f80e4c', title: 'Generic information disclosure threat', type: 'Information disclosure', status: 'Open', severity: 'Medium', description: 'A generic information disclosure threat' });
-            });
+        engine.addRule({
+            conditions: {
+                any: [{
+                    fact: 'el',
+                    path: '.element.attributes.type',
+                    operator: 'equal',
+                    value: 'tm.Process'
+                }, {
+                    fact: 'el',
+                    path: '.element.attributes.type',
+                    operator: 'equal',
+                    value: 'tm.Store'                        
+                } , {
+                    fact: 'el',
+                    path: '.element.attributes.type',
+                    operator: 'equal',
+                    value: 'tm.Flow'                        
+                }]
+            },
+            event: {
+                type: '13000296-b17d-4b72-9cc4-f5cc33f80e4c',
+                params: {
+                    ruleId: '13000296-b17d-4b72-9cc4-f5cc33f80e4c',
+                    title: 'Generic informtion disclosure threat',
+                    type: 'Information disclosure',
+                    status: 'Open',
+                    severity: 'Medium',
+                    description: 'A generic information disclosure threat'
+                }
+            }
+        });
 
-            flow.rule('Generic Denial of Service Threat Rule', [
-                ['or',
-                    [Element, 'el', 'el.element.attributes.type == "tm.Process"'],
-                    [Element, 'el', 'el.element.attributes.type == "tm.Store"'],
-                    [Element, 'el', 'el.element.attributes.type == "tm.Flow"']
-                ],
-                [Threats, 'threats']
-            ], function (facts) {
-                facts.threats.collection.push({ ruleId: 'edb05d76-a695-455f-947b-7d67b78bc31d', title: 'Generic DoS threat', type: 'Denial of service', status: 'Open', severity: 'Medium', description: 'A generic DoS threat' });
-            });
+        engine.addRule({
+            conditions: {
+                any: [{
+                    fact: 'el',
+                    path: '.element.attributes.type',
+                    operator: 'equal',
+                    value: 'tm.Process'
+                }, {
+                    fact: 'el',
+                    path: '.element.attributes.type',
+                    operator: 'equal',
+                    value: 'tm.Store'                        
+                } , {
+                    fact: 'el',
+                    path: '.element.attributes.type',
+                    operator: 'equal',
+                    value: 'tm.Flow'                        
+                }]
+            },
+            event: {
+                type: 'edb05d76-a695-455f-947b-7d67b78bc31d',
+                params: {
+                    ruleId: 'edb05d76-a695-455f-947b-7d67b78bc31d',
+                    title: 'Generic DoS threat',
+                    type: 'Denial of service',
+                    status: 'Open',
+                    severity: 'Medium',
+                    description: 'A generic DoS threat'
+                }
+            }
+        });
 
-            flow.rule('Generic Elevation of Privilege Rule', [
-                ['or',
-                    [Element, 'el', 'el.element.attributes.type == "tm.Process"']
-                ],
-                [Threats, 'threats']
-            ], function (facts) {
-                facts.threats.collection.push({ ruleId: 'c1377855-ea20-4c97-8861-f95c364fb8d2', title: 'Generic elevation threat', type: 'Elevation of privilege', status: 'Open', severity: 'Medium', description: 'A generic elevation threat' });
-            });
+        engine.addRule({
+            conditions: {
+                any: [{
+                    fact: 'el',
+                    path: '.element.attributes.type',
+                    operator: 'equal',
+                    value: 'tm.Process'                       
+                }]
+            },
+            event: {
+                type: 'c1377855-ea20-4c97-8861-f95c364fb8d2',
+                params: {
+                    ruleId: 'c1377855-ea20-4c97-8861-f95c364fb8d2',
+                    title: 'Generic elevation threat',
+                    type: 'Elevation of privilege',
+                    status: 'Open',
+                    severity: 'Medium',
+                    description: 'A generic elevation threat'
+                }
+            }
+        });
 
-            flow.rule('Should encrypt on public network', [
-                [Element, 'el', 'el.element.attributes.type == "tm.Flow" && isTrue(el.element.isPublicNetwork) && ( isFalse(el.element.isEncrypted) || isUndefined(el.element.isEncrypted) )'],
-                [Threats, 'threats']
-            ], function (facts) {
-                facts.threats.collection.push({
+        engine.addRule({
+            conditions: {
+                all: [{
+                    fact: 'el',
+                    path: '.element.attributes.type',
+                    operator: 'equal',
+                    value: 'tm.Flow'
+                } , {
+                    fact: 'el',
+                    path: '.element.isPublicNetwork',
+                    operator: 'equal',
+                    value: true                                            
+                } , {
+                    any: [{                    
+                        fact: 'el',
+                        path: '.element.isEncrypted',
+                        operator: 'equal',
+                        value: false
+                    }, {
+                        fact: 'el',
+                        path: '.element.isEncrypted',
+                        operator: 'equal',
+                        value: undefined   
+                    }]                                                                                
+                }]
+            },
+            event: {
+                type: 'c1cae982-3e92-4bb2-b50b-ea51137fc3a7',
+                params: {
                     ruleId: 'c1cae982-3e92-4bb2-b50b-ea51137fc3a7',
                     title: 'Use encryption',
                     type: 'Information disclosure',
@@ -124,8 +258,8 @@ function threatengine() {
                     severity: 'High',
                     description: 'Unencrypted data sent over a public network may be intercepted and read by an attacker.',
                     mitigation: 'Data sent over a public network should be encrypted either at the message or transport level.'
-                });
-            });
+                }
+            }
         });
     }
 }

--- a/test/spec/threatengine_spec.js
+++ b/test/spec/threatengine_spec.js
@@ -88,6 +88,63 @@ describe('threatengine service:', function () {
 
         });
 
+        //give a description for the rule
+        it('should suggest using encryption over public networks (undefined encryption)', function (done) {
+
+            //set up the properties of the element
+            var subject = { attributes: { type: 'tm.Flow' }, isPublicNetwork: true };
+
+            //generate the threats
+            threatengine.generateForElement(subject).then(function (threats) {
+
+                expect(threats).toBeDefined();
+                var ruleIds = _.uniq(_.map(threats, 'ruleId'));
+                //grab a new UUID for your rule from https://www.guidgenerator.com/ and expect it to 
+                //be in the generated threats
+                expect(ruleIds.indexOf('c1cae982-3e92-4bb2-b50b-ea51137fc3a7')).toBeGreaterThan(-1);
+                done();
+            })
+
+        });
+
+        //give a description for the rule
+        it('should not suggest using encryption over public networks (not public)', function (done) {
+
+            //set up the properties of the element
+            var subject = { attributes: { type: 'tm.Flow' }, isPublicNetwork: false, isEncrypted: true };
+
+            //generate the threats
+            threatengine.generateForElement(subject).then(function (threats) {
+
+                expect(threats).toBeDefined();
+                var ruleIds = _.uniq(_.map(threats, 'ruleId'));
+                //grab a new UUID for your rule from https://www.guidgenerator.com/ and expect it to 
+                //be in the generated threats
+                expect(ruleIds.indexOf('c1cae982-3e92-4bb2-b50b-ea51137fc3a7')).toEqual(-1);
+                done();
+            })
+
+        });
+
+        //give a description for the rule
+        it('should not suggest using encryption over public networks (already encrypted)', function (done) {
+
+            //set up the properties of the element
+            var subject = { attributes: { type: 'tm.Flow' }, isPublicNetwork: true, isEncrypted: true };
+
+            //generate the threats
+            threatengine.generateForElement(subject).then(function (threats) {
+
+                expect(threats).toBeDefined();
+                var ruleIds = _.uniq(_.map(threats, 'ruleId'));
+                //grab a new UUID for your rule from https://www.guidgenerator.com/ and expect it to 
+                //be in the generated threats
+                expect(ruleIds.indexOf('c1cae982-3e92-4bb2-b50b-ea51137fc3a7')).toEqual(-1);
+                done();
+            })
+
+        });
+
     });
 
     describe('element in context generation tests', function () {


### PR DESCRIPTION
nools replaced by json-rules-engine since nools is not supported. also should enable removal of unsafe-eval in csp