### PR TITLE
Add: Duplicate diagrams and elements

### DIFF
--- a/src/diagrams/diagram.js
+++ b/src/diagrams/diagram.js
@@ -15,6 +15,11 @@ function diagram($scope, $location, $routeParams, $timeout, dialogs, common, dat
     var threatWatchers = [];
     var gridSizeOn = 10;
     var gridSizeOff = 1;
+    var elementsDict = { "tm.Process" : newProcess,
+                        "tm.Store" : newStore,
+                        "tm.Actor" : newActor,
+                        "tm.Flow" : newFlow,
+                        "tm.Boundary" : newBoundary}
 
     // Bindable properties and functions are placed on vm.
     vm.errored = false;
@@ -28,10 +33,12 @@ function diagram($scope, $location, $routeParams, $timeout, dialogs, common, dat
     vm.newFlow = newFlow;
     vm.newActor = newActor;
     vm.newBoundary = newBoundary;
+    vm.cloneElement = cloneElement;
     vm.getThreatModelPath = getThreatModelPath;
     vm.select = select;
     vm.edit = edit;
     vm.generateThreats = generateThreats;
+    vm.duplicateElement = duplicateElement;
     vm.setGrid = setGrid;
     vm.showGrid = false;
     vm.selected = null;
@@ -208,6 +215,27 @@ function diagram($scope, $location, $routeParams, $timeout, dialogs, common, dat
         }
     }
 
+    function duplicateElement() {
+        if (vm.selected) {
+            var newElement = cloneElement(vm.selected);
+
+            if (newElement.attributes.type == "tm.Flow") {    
+                newElement.attributes.source = {'x' : 30, 'y' : 20}
+                newElement.attributes.target = {'x' : 110, 'y' : 100}
+                newElement.attributes.labels[0].attrs.text['text'] = 'Copy of ' + newElement.attributes.labels[0].attrs.text['text']
+                delete newElement.attributes.vertices
+            }
+            else {
+                var height = newElement.attributes.size.height + 20
+                newElement.attributes.position.y += height
+                newElement.attributes.attrs.text.text = 'Copy of ' + newElement.attributes.attrs.text.text
+            }
+
+            var diagramData = { diagramJson: { cells: vm.graph.getCells() } };
+            vm.graph.initialise(diagramData.diagramJson);
+        }
+    }
+
     function onGenerateThreats(threats) {
         var threatTotal = threats.length;
         var threatList = threats;
@@ -323,6 +351,10 @@ function diagram($scope, $location, $routeParams, $timeout, dialogs, common, dat
     function newBoundary() {
 
         return vm.graph.addBoundary();
+    }
+
+    function cloneElement(element){
+        return watchThreats(vm.graph.duplicateElement(element));
     }
 
     function addDirtyEventHandlers() {

--- a/src/diagrams/diagrameditor.html
+++ b/src/diagrams/diagrameditor.html
@@ -67,6 +67,9 @@
                                 <button class="btn btn-default" ng-disabled="vm.selected == null || vm.selected.outOfScope" type="button" data-toggle="tooltip" ng-click="vm.generateThreats()" data-placement="top" title="Suggest threats for the selected element">
                                     <span class="glyphicon glyphicon-flash" aria-hidden="true"></span>
                                 </button>
+                                <button class="btn btn-default" ng-disabled="vm.selected == null" type="button" data-toggle="tooltip" ng-click="vm.duplicateElement()" data-placement="top" title="Duplicate the selected element">
+                                    <span class="glyphicon glyphicon-duplicate" aria-hidden="true"></span>
+                                </button>
                                 <button class="btn btn-default" ng-disabled="!vm.dirty" type="button" data-toggle="tooltip" ng-click="vm.save()" data-placement="top" title="Save This Diagram">
                                     <span class="glyphicon glyphicon-save" aria-hidden="true"></span>
                                 </button>

--- a/src/services/diagramming.js
+++ b/src/services/diagramming.js
@@ -49,6 +49,15 @@ function diagramming() {
         return cell;
     };
 
+    joint.dia.Graph.prototype.duplicateElement = function (cell) {
+        var cloneDict = this.cloneCells([cell]) 
+        var firstElement = Object.keys(cloneDict)[0]
+        var clonedCell = cloneDict[firstElement]  
+        this.addCell(clonedCell);
+
+        return clonedCell;
+    };
+
     joint.dia.Graph.prototype.clearAll = function () {
         this.clear(true);
     };

--- a/src/threatmodels/threatmodel.js
+++ b/src/threatmodels/threatmodel.js
@@ -18,6 +18,7 @@ function threatModel($scope, $location, $routeParams, dialogs, common, dataconte
     vm.removeContributor = removeContributor;
     vm.addContributor = addContributor;
     vm.removeDiagram = removeDiagram;
+    vm.duplicateDiagram = duplicateDiagram;
     vm.addDiagram = addDiagram;
     vm.save = save;
     vm.create = create;
@@ -149,6 +150,25 @@ function threatModel($scope, $location, $routeParams, dialogs, common, dataconte
 
     function removeDiagram(index) {
         vm.threatModel.detail.diagrams.splice(index, 1);
+
+        var diagramsArrayLength = vm.threatModel.detail.diagrams.length
+        
+        vm.threatModel.detail.diagrams.forEach(function (item, index) {
+            item.id = index
+        });
+        
+        vm.dirty = true;
+    }
+
+    function duplicateDiagram(index) {
+        var duplicatedDiagram = angular.copy(vm.threatModel.detail.diagrams[index]);
+        vm.newDiagram.title = "Copy of " + duplicatedDiagram.title;
+        vm.newDiagram.id = vm.threatModel.detail.diagrams.length;
+        vm.newDiagram.diagramJson = duplicatedDiagram.diagramJson;
+        vm.newDiagram.size = duplicatedDiagram.size;
+        vm.threatModel.detail.diagrams.push(vm.newDiagram);
+        vm.newDiagram = emptyDiagram();
+        vm.addingDiagram = false;
         vm.dirty = true;
     }
 

--- a/src/threatmodels/threatmodeledit.html
+++ b/src/threatmodels/threatmodeledit.html
@@ -112,9 +112,12 @@
                                     <input name="diagramTitle" class="form-control" type="text" ng-model="diagram.title" required placeholder="Diagram title"
                                     />
                                     <span class="input-group-btn">
+                                        <button class="btn btn-primary" data-toggle="tooltip" ng-click="vm.duplicateDiagram($index)" data-placement="top" title="Duplicate This Diagram" aria-hidden="true" type="button">
+                                            <span class="glyphicon glyphicon-duplicate"></span>                                    Duplicate
+                                        </button>
                                         <button class="btn btn-default" data-toggle="tooltip" ng-click="vm.removeDiagram($index)" data-placement="top" title="Remove This Diagram" aria-hidden="true" type="button">
                                             <span class="glyphicon glyphicon-remove"></span>                                    Remove
-                                    </button>
+                                        </button>
                                     </span>
                                 </div>
                             </p>


### PR DESCRIPTION
Adds the ability to duplicate (clone) a diagram in the edit view of a model, and the ability to duplicate an element of the diagram (and its properties) in the diagram view. Also provides a small fix for a bug where two diagrams would have the same ID after deleting then adding a diagram.