### PR TITLE
Create boundary name

### DIFF
--- a/src/content/joint-custom.css
+++ b/src/content/joint-custom.css
@@ -66,6 +66,10 @@ text.hasOpenThreats  {
 	font-size: small
 }
 
+.joint-type-tm-boundary .link-tool .tool-options {
+	display: inline;
+}  
+
 /* responsive paper */
 
 .tmt-diagram-container {

--- a/src/content/threatdragon-core.css
+++ b/src/content/threatdragon-core.css
@@ -8919,6 +8919,10 @@ text.hasOpenThreats {
   font-size: small;
 }
 
+.joint-type-tm-boundary .link-tool .tool-options {
+  display: inline;
+}
+
 /* responsive paper */
 
 .tmt-diagram-container {

--- a/src/content/threatdragon-core.css
+++ b/src/content/threatdragon-core.css
@@ -8919,10 +8919,6 @@ text.hasOpenThreats {
   font-size: small;
 }
 
-.joint-type-tm-boundary .link-tool .tool-options {
-  display: inline;
-}
-
 /* responsive paper */
 
 .tmt-diagram-container {

--- a/src/diagrams/ElementPropertiesPane.html
+++ b/src/diagrams/ElementPropertiesPane.html
@@ -5,14 +5,16 @@
             <input name="nameInput" class="form-control" type="text" ng-model="selected.name" ng-change="edit()" placeholder="Element name" />
         </div>
     </div>
-    <div class="checkbox">
-        <label>
-            <input name="checkboxOutOfScope" type="checkbox" ng-model="selected.outOfScope" ng-change="edit()" /> Out of scope
-        </label>
-    </div>
-    <div class="form-group">
-        <label>Reason for out of scope</label>
-        <textarea name="textareaReasonOutOfScope" ng-disabled="!selected.outOfScope" rows="4" class="form-control" type="text" ng-model="selected.reasonOutOfScope" ng-change="edit()" placeholder="Reason for out of scope"></textarea>
+    <div ng-show="elementType !== 'tm.Boundary'">
+        <div class="checkbox">
+            <label>
+                <input name="checkboxOutOfScope" type="checkbox" ng-model="selected.outOfScope" ng-change="edit()" /> Out of scope
+            </label>
+        </div>
+        <div class="form-group">
+            <label>Reason for out of scope</label>
+            <textarea name="textareaReasonOutOfScope" ng-disabled="!selected.outOfScope" rows="4" class="form-control" type="text" ng-model="selected.reasonOutOfScope" ng-change="edit()" placeholder="Reason for out of scope"></textarea>
+        </div>
     </div>
     <div ng-show="elementType === 'tm.Process'">
         <div class="form-group">

--- a/src/diagrams/diagram.js
+++ b/src/diagrams/diagram.js
@@ -214,13 +214,7 @@ function diagram($scope, $location, $routeParams, $timeout, dialogs, common, dat
         if (vm.selected) {
             var newElement = vm.cloneElement(vm.selected);
 
-            if (newElement.attributes.type == "tm.Flow") {    
-                newElement.attributes.source = {'x' : 30, 'y' : 20};
-                newElement.attributes.target = {'x' : 110, 'y' : 100};
-                newElement.attributes.labels[0].attrs.text.text = 'Copy of ' + newElement.attributes.labels[0].attrs.text.text;
-                delete newElement.attributes.vertices;
-            }
-            else if (newElement.attributes.type == "tm.Boundary") {
+            if (newElement.attributes.type == "tm.Flow" || newElement.attributes.type == "tm.Boundary") {    
                 newElement.attributes.source = {'x' : 30, 'y' : 20};
                 newElement.attributes.target = {'x' : 110, 'y' : 100};
                 newElement.attributes.labels[0].attrs.text.text = 'Copy of ' + newElement.attributes.labels[0].attrs.text.text;

--- a/src/diagrams/diagram.js
+++ b/src/diagrams/diagram.js
@@ -212,9 +212,15 @@ function diagram($scope, $location, $routeParams, $timeout, dialogs, common, dat
 
     function duplicateElement() {
         if (vm.selected) {
-            var newElement = cloneElement(vm.selected);
+            var newElement = vm.cloneElement(vm.selected);
 
             if (newElement.attributes.type == "tm.Flow") {    
+                newElement.attributes.source = {'x' : 30, 'y' : 20};
+                newElement.attributes.target = {'x' : 110, 'y' : 100};
+                newElement.attributes.labels[0].attrs.text.text = 'Copy of ' + newElement.attributes.labels[0].attrs.text.text;
+                delete newElement.attributes.vertices;
+            }
+            else if (newElement.attributes.type == "tm.Boundary") {
                 newElement.attributes.source = {'x' : 30, 'y' : 20};
                 newElement.attributes.target = {'x' : 110, 'y' : 100};
                 newElement.attributes.labels[0].attrs.text.text = 'Copy of ' + newElement.attributes.labels[0].attrs.text.text;

--- a/src/diagrams/diagram.js
+++ b/src/diagrams/diagram.js
@@ -214,24 +214,29 @@ function diagram($scope, $location, $routeParams, $timeout, dialogs, common, dat
         if (vm.selected) {
             var newElement = vm.cloneElement(vm.selected);
 
+            var label = "";
+            if (typeof newElement.attributes.labels != "undefined"){
+                label = 'Copy of ' + newElement.attributes.labels[0].attrs.text.text;   
+            }
+
             if (newElement.attributes.type == "tm.Flow") {    
                 newElement.attributes.source = {'x' : 30, 'y' : 20};
                 newElement.attributes.target = {'x' : 110, 'y' : 100};
-                newElement.attributes.labels[0].attrs.text.text = 'Copy of ' + newElement.attributes.labels[0].attrs.text.text;
+                newElement.attributes.labels[0].attrs.text.text = label;
                 delete newElement.attributes.vertices;
             }
             else if (newElement.attributes.type == "tm.Boundary") {    
                 newElement.attributes.source = {'x' : 30, 'y' : 20};
                 newElement.attributes.target = {'x' : 110, 'y' : 100};
-                if (typeof newElement.attributes.labels != "undefined"){
-                    newElement.attributes.labels[0].attrs.text.text = 'Copy of ' + newElement.attributes.labels[0].attrs.text.text;   
+                if (label != ""){
+                    newElement.attributes.labels[0].attrs.text.text = label;
                 }
                 delete newElement.attributes.vertices;
             }
             else {
                 var height = newElement.attributes.size.height + 20;
                 newElement.attributes.position.y += height;
-                newElement.attributes.attrs.text.text = 'Copy of ' + newElement.attributes.attrs.text.text;
+                newElement.attributes.attrs.text.text = label;
             }
 
             var diagramData = { diagramJson: { cells: vm.graph.getCells() } };

--- a/src/diagrams/diagram.js
+++ b/src/diagrams/diagram.js
@@ -214,10 +214,18 @@ function diagram($scope, $location, $routeParams, $timeout, dialogs, common, dat
         if (vm.selected) {
             var newElement = vm.cloneElement(vm.selected);
 
-            if (newElement.attributes.type == "tm.Flow" || newElement.attributes.type == "tm.Boundary") {    
+            if (newElement.attributes.type == "tm.Flow") {    
                 newElement.attributes.source = {'x' : 30, 'y' : 20};
                 newElement.attributes.target = {'x' : 110, 'y' : 100};
                 newElement.attributes.labels[0].attrs.text.text = 'Copy of ' + newElement.attributes.labels[0].attrs.text.text;
+                delete newElement.attributes.vertices;
+            }
+            else if (newElement.attributes.type == "tm.Boundary") {    
+                newElement.attributes.source = {'x' : 30, 'y' : 20};
+                newElement.attributes.target = {'x' : 110, 'y' : 100};
+                if (typeof newElement.attributes.labels != "undefined"){
+                    newElement.attributes.labels[0].attrs.text.text = 'Copy of ' + newElement.attributes.labels[0].attrs.text.text;   
+                }
                 delete newElement.attributes.vertices;
             }
             else {

--- a/src/diagrams/diagram.js
+++ b/src/diagrams/diagram.js
@@ -220,6 +220,12 @@ function diagram($scope, $location, $routeParams, $timeout, dialogs, common, dat
                 newElement.attributes.labels[0].attrs.text.text = 'Copy of ' + newElement.attributes.labels[0].attrs.text.text;
                 delete newElement.attributes.vertices;
             }
+            else if (newElement.attributes.type == "tm.Boundary") {
+                newElement.attributes.source = {'x' : 30, 'y' : 20};
+                newElement.attributes.target = {'x' : 110, 'y' : 100};
+                newElement.attributes.labels[0].attrs.text.text = 'Copy of ' + newElement.attributes.labels[0].attrs.text.text;
+                delete newElement.attributes.vertices;
+            }
             else {
                 var height = newElement.attributes.size.height + 20;
                 newElement.attributes.position.y += height;

--- a/src/diagrams/diagram.js
+++ b/src/diagrams/diagram.js
@@ -219,13 +219,7 @@ function diagram($scope, $location, $routeParams, $timeout, dialogs, common, dat
                 label = 'Copy of ' + newElement.attributes.labels[0].attrs.text.text;   
             }
 
-            if (newElement.attributes.type == "tm.Flow") {    
-                newElement.attributes.source = {'x' : 30, 'y' : 20};
-                newElement.attributes.target = {'x' : 110, 'y' : 100};
-                newElement.attributes.labels[0].attrs.text.text = label;
-                delete newElement.attributes.vertices;
-            }
-            else if (newElement.attributes.type == "tm.Boundary") {    
+            if (newElement.attributes.type == "tm.Flow" || newElement.attributes.type == "tm.Boundary") {    
                 newElement.attributes.source = {'x' : 30, 'y' : 20};
                 newElement.attributes.target = {'x' : 110, 'y' : 100};
                 if (label != ""){

--- a/src/diagrams/diagrameditor.html
+++ b/src/diagrams/diagrameditor.html
@@ -87,10 +87,10 @@
             <div class="panel panel-default">
                 <div class="panel-heading panel-title">Properties</div>
                 <div class="panel-body">
-                    <div ng-if="vm.selected && vm.selected.attributes.type != 'tm.Boundary' ">
+                    <div ng-if="vm.selected">
                         <tmt-element-properties edit=" vm.edit()" selected="vm.selected" element-type="{{vm.selected.attributes.type}}">
                     </div>
-                    <div ng-if="!vm.selected || vm.selected.attributes.type === 'tm.Boundary'">
+                    <div ng-if="!vm.selected">
                         <em>Select an element in the diagram to see or edit its properties</em>
                     </div>
                 </div>

--- a/src/diagrams/diagrameditor.html
+++ b/src/diagrams/diagrameditor.html
@@ -64,7 +64,7 @@
                                 <button class="btn btn-default" ng-disabled="!vm.dirty" type="button" data-toggle="tooltip" ng-click="vm.reload()" data-placement="top" title="Discard Changes And Reopen Diagram">
                                     <span class="fa fa-undo" aria-hidden="true"></span>
                                 </button>
-                                <button class="btn btn-default" ng-disabled="vm.selected == null || vm.selected.outOfScope" type="button" data-toggle="tooltip" ng-click="vm.generateThreats()" data-placement="top" title="Suggest threats for the selected element">
+                                <button class="btn btn-default" ng-disabled="vm.selected == null || vm.selected.outOfScope || vm.selected.attributes.type == 'tm.Boundary'" type="button" data-toggle="tooltip" ng-click="vm.generateThreats()" data-placement="top" title="Suggest threats for the selected element">
                                     <span class="glyphicon glyphicon-flash" aria-hidden="true"></span>
                                 </button>
                                 <button class="btn btn-default" ng-disabled="vm.selected == null" type="button" data-toggle="tooltip" ng-click="vm.duplicateElement()" data-placement="top" title="Duplicate the selected element">

--- a/src/services/diagramming.js
+++ b/src/services/diagramming.js
@@ -43,7 +43,7 @@ function diagramming() {
     };
 
     joint.dia.Graph.prototype.addBoundary = function (source, target, label) {
-        var name = label ? label : 'boundary ' + this.attributes.cells.length;
+        var name = label ? label : "";
         var cell = boundary(source, target, name);
         this.addCell(cell);
 

--- a/src/services/diagramming.js
+++ b/src/services/diagramming.js
@@ -43,7 +43,8 @@ function diagramming() {
     };
 
     joint.dia.Graph.prototype.addBoundary = function (source, target, label) {
-        var cell = boundary(source, target, label);
+        var name = label ? label : 'boundary ' + this.attributes.cells.length;
+        var cell = boundary(source, target, name);
         this.addCell(cell);
 
         return cell;

--- a/src/services/joint.shapes.tm.js
+++ b/src/services/joint.shapes.tm.js
@@ -181,6 +181,31 @@ joint.shapes.tm.Boundary = joint.dia.Link.extend({
     }, joint.dia.Link.prototype.defaults)
 });
 
+//trust boundary properties
+
+Object.defineProperty(joint.shapes.tm.Boundary.prototype, 'name', {
+    get: function () { 
+            //Need to make it backward compatible with prev versions that do not have name 
+            //on the boundaries by creating an empty string field
+            var nameProperty = "";
+            if ('labels' in this.attributes) {
+                nameProperty = this.attributes.labels[0].attrs.text.text;
+            }
+            return joint.shapes.tm.utils.wordUnwrap(nameProperty); 
+        },
+    set: function (value) { 
+            joint.shapes.tm.utils.editNameLink(this, value); 
+
+            //For backward compatibility: Adjust old boundary attributes with current ones
+            if (!('font-weight' in this.attributes.labels[0].attrs.text) || !('font-size' in this.attributes.labels[0].attrs.text)) {
+                this.attributes.labels[0] = { position: 0.5, attrs: { text: { text: value, 'font-weight': '400', 'font-size': 'small' } } };
+                
+                var diagramData = { diagramJson: { cells: this.graph.getCells() } };
+                this.graph.initialise(diagramData.diagramJson);
+            }
+        }
+});
+
 //element with tool bar
 
 joint.shapes.tm.toolElement = joint.shapes.basic.Generic.extend({

--- a/src/templates.js
+++ b/src/templates.js
@@ -82,7 +82,7 @@ angular.module('templates', [])
     '                                <button class="btn btn-default" ng-disabled="!vm.dirty" type="button" data-toggle="tooltip" ng-click="vm.reload()" data-placement="top" title="Discard Changes And Reopen Diagram">\n' +
     '                                    <span class="fa fa-undo" aria-hidden="true"></span>\n' +
     '                                </button>\n' +
-    '                                <button class="btn btn-default" ng-disabled="vm.selected == null || vm.selected.outOfScope" type="button" data-toggle="tooltip" ng-click="vm.generateThreats()" data-placement="top" title="Suggest threats for the selected element">\n' +
+    '                                <button class="btn btn-default" ng-disabled="vm.selected == null || vm.selected.outOfScope || vm.selected.attributes.type == \'tm.Boundary\'" type="button" data-toggle="tooltip" ng-click="vm.generateThreats()" data-placement="top" title="Suggest threats for the selected element">\n' +
     '                                    <span class="glyphicon glyphicon-flash" aria-hidden="true"></span>\n' +
     '                                </button>\n' +
     '                                <button class="btn btn-default" ng-disabled="vm.selected == null" type="button" data-toggle="tooltip" ng-click="vm.duplicateElement()" data-placement="top" title="Duplicate the selected element">\n' +

--- a/src/templates.js
+++ b/src/templates.js
@@ -105,10 +105,10 @@ angular.module('templates', [])
     '            <div class="panel panel-default">\n' +
     '                <div class="panel-heading panel-title">Properties</div>\n' +
     '                <div class="panel-body">\n' +
-    '                    <div ng-if="vm.selected && vm.selected.attributes.type != \'tm.Boundary\' ">\n' +
+    '                    <div ng-if="vm.selected">\n' +
     '                        <tmt-element-properties edit=" vm.edit()" selected="vm.selected" element-type="{{vm.selected.attributes.type}}">\n' +
     '                    </div>\n' +
-    '                    <div ng-if="!vm.selected || vm.selected.attributes.type === \'tm.Boundary\'">\n' +
+    '                    <div ng-if="!vm.selected">\n' +
     '                        <em>Select an element in the diagram to see or edit its properties</em>\n' +
     '                    </div>\n' +
     '                </div>\n' +
@@ -139,14 +139,16 @@ angular.module('templates', [])
     '            <input name="nameInput" class="form-control" type="text" ng-model="selected.name" ng-change="edit()" placeholder="Element name" />\n' +
     '        </div>\n' +
     '    </div>\n' +
-    '    <div class="checkbox">\n' +
-    '        <label>\n' +
-    '            <input name="checkboxOutOfScope" type="checkbox" ng-model="selected.outOfScope" ng-change="edit()" /> Out of scope\n' +
-    '        </label>\n' +
-    '    </div>\n' +
-    '    <div class="form-group">\n' +
-    '        <label>Reason for out of scope</label>\n' +
-    '        <textarea name="textareaReasonOutOfScope" ng-disabled="!selected.outOfScope" rows="4" class="form-control" type="text" ng-model="selected.reasonOutOfScope" ng-change="edit()" placeholder="Reason for out of scope"></textarea>\n' +
+    '    <div ng-show="elementType !== \'tm.Boundary\'">\n' +
+    '        <div class="checkbox">\n' +
+    '            <label>\n' +
+    '                <input name="checkboxOutOfScope" type="checkbox" ng-model="selected.outOfScope" ng-change="edit()" /> Out of scope\n' +
+    '            </label>\n' +
+    '        </div>\n' +
+    '        <div class="form-group">\n' +
+    '            <label>Reason for out of scope</label>\n' +
+    '            <textarea name="textareaReasonOutOfScope" ng-disabled="!selected.outOfScope" rows="4" class="form-control" type="text" ng-model="selected.reasonOutOfScope" ng-change="edit()" placeholder="Reason for out of scope"></textarea>\n' +
+    '        </div>\n' +
     '    </div>\n' +
     '    <div ng-show="elementType === \'tm.Process\'">\n' +
     '        <div class="form-group">\n' +

--- a/test/spec/diagram_spec.js
+++ b/test/spec/diagram_spec.js
@@ -253,6 +253,22 @@ describe('diagram controller', function () {
             expect($scope.vm.cloneElement).toHaveBeenCalled();
         });
 
+        it('should duplicate a boundary element', function() {
+
+            var graph = {title: 'test graph'};
+            var label = { text : { text : "boundaryName"} };
+            var element = {id: 'elementId', attributes: {type : "tm.Boundary", position : { y : 10}, attrs : label}};
+            graph.duplicateElement = function() { return {id: 'newElementId', 
+                                    attributes: {type : "tm.Boundary", size : {height : 30}, position : { y : 10}, attrs : label}}};
+            graph.getCells = function() {};
+            graph.initialise = function() {};
+            spyOn($scope.vm, 'cloneElement').and.callThrough();
+            $scope.vm.graph = graph;
+            $scope.vm.selected = element;
+            $scope.vm.duplicateElement();
+            expect($scope.vm.cloneElement).toHaveBeenCalled();
+        });
+
         it('should not duplicate an element - no element selected', function() {
 
             var graph = {title: 'test graph'};

--- a/test/spec/diagramming_spec.js
+++ b/test/spec/diagramming_spec.js
@@ -348,9 +348,9 @@ describe('diagramming service:', function () {
 
             });
 
-            it('should get the label for a boundary', function () {
+            it('should get an empty label for a boundary', function () {
 
-                expect(boundary.name).toEqual('boundary 2');
+                expect(boundary.name).toEqual('');
 
             });
 

--- a/test/spec/diagramming_spec.js
+++ b/test/spec/diagramming_spec.js
@@ -325,12 +325,14 @@ describe('diagramming service:', function () {
             var graph;
             var process;
             var flow;
+            var boundary;
 
             beforeEach(function () {
 
                 graph = new joint.dia.Graph();
                 process = graph.addProcess();
                 flow = graph.addFlow();
+                boundary = graph.addBoundary();
 
             });
 
@@ -346,6 +348,12 @@ describe('diagramming service:', function () {
 
             });
 
+            it('should get the label for a boundary', function () {
+
+                expect(boundary.name).toEqual('boundary 2');
+
+            });
+
             it('should set the label for an element', function () {
 
                 process.name = 'new name'
@@ -357,6 +365,13 @@ describe('diagramming service:', function () {
 
                 flow.name = 'new name';
                 expect(flow.name).toEqual('new name');
+
+            });
+
+            it('should set the label for a boundary', function () {
+
+                boundary.name = 'new name';
+                expect(boundary.name).toEqual('new name');
 
             });
 

--- a/test/spec/shapes_spec.js
+++ b/test/spec/shapes_spec.js
@@ -425,6 +425,16 @@ describe('custom shape tests', function () {
             expect(diagramElement.find('g.label').find('tspan')[0]).toContainText(label);
         });
 
+        it('should remove line breaks from boundary name', function () {
+
+            var label = 'boundary';
+            cell.setLabel(label);
+            var multiLineName = '1\n2\n3';
+            var singleLineName = '1 2 3';
+            cell.name = multiLineName;
+            expect(cell.name).toEqual(singleLineName);
+        });
+
     });
 
     describe(' :flow', function () {


### PR DESCRIPTION
#78 
Boundaries are now created with a label to be able to identify different boundaries similarly to a flow. It should not affect previous boundaries created (without a name) and they can still be saved without a name, or a name can be added if needed.