### PR TITLE
Add hotkeys to diagram

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ npm-debug.log
 package-lock.json
 # ignore Apple's desktop store files
 **/.DS_Store
-# ignore VS and Eclipse files
+# ignore IDE files
 .vscode/
 .settings/
+*.iml

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": false,
   "scripts": {
     "build": "npm run bundle-css && npm run build-templates",
-    "build-templates": "./node_modules/.bin/npm-html2js -b src -i 'src/**/*.html' --module templates -o './src/templates.js'",
+    "build-templates": "./node_modules/.bin/npm-html2js -b src -i \"src/**/*.html\" --module templates -o ./src/templates.js\"",
     "pretest": "node ./node_modules/jshint/bin/jshint --verbose --show-non-errors src",
     "bundle-css": "./node_modules/.bin/rework-npm ./src/content/app.css -o ./src/content/threatdragon-core.css",
     "test": "npm run-script test-client-phantomjs && npm run-script test-client-firefox",
@@ -36,6 +36,7 @@
     "angular-route": "1.7.8",
     "angular-ui-bootstrap": "2.5.6",
     "bootstrap": "3.4.1",
+    "hotkeys-js": "^3.7.6",
     "jointjs": "^2.2.1",
     "jquery": "^3.4.1",
     "json-rules-engine": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": false,
   "scripts": {
     "build": "npm run bundle-css && npm run build-templates",
-    "build-templates": "./node_modules/.bin/npm-html2js -b src -i \"src/**/*.html\" --module templates -o ./src/templates.js\"",
+    "build-templates": "./node_modules/.bin/npm-html2js -b src -i \"src/**/*.html\" --module templates -o \"./src/templates.js\"",
     "pretest": "node ./node_modules/jshint/bin/jshint --verbose --show-non-errors src",
     "bundle-css": "./node_modules/.bin/rework-npm ./src/content/app.css -o ./src/content/threatdragon-core.css",
     "test": "npm run-script test-client-phantomjs && npm run-script test-client-firefox",

--- a/src/content/joint-custom.css
+++ b/src/content/joint-custom.css
@@ -16,6 +16,10 @@
 	stroke-width: 3
 }
 
+.joint-paper:focus {
+    outline: none
+}
+
 /*threat model status indicator classes*/
 
 .isOutOfScope {

--- a/src/content/threatdragon-core.css
+++ b/src/content/threatdragon-core.css
@@ -8869,6 +8869,10 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
   stroke-width: 3;
 }
 
+.joint-paper:focus {
+  outline: none;
+}
+
 /*threat model status indicator classes*/
 
 .isOutOfScope {

--- a/src/diagrams/diagram.js
+++ b/src/diagrams/diagram.js
@@ -57,9 +57,9 @@ function diagram($scope, $document, $location, $routeParams, $timeout, dialogs, 
     vm.currentZoomLevel = 0;
     vm.maxZoom = 4;
 
-    hotkeys("Escape", escapeHotkey);
-    hotkeys("Ctrl+C", copyHotkey);
-    hotkeys("Ctrl+V", pasteHotkey);
+    hotkeys('Escape', escapeHotkey);
+    hotkeys('Cmd+C, Ctrl+C', copyHotkey);
+    hotkeys('Cmd+V, Ctrl+V', pasteHotkey);
 
     //structured exit
     $scope.$on('$locationChangeStart', function (event, current, previous) {
@@ -79,9 +79,9 @@ function diagram($scope, $document, $location, $routeParams, $timeout, dialogs, 
 
 
     $scope.$on('$destroy', function () {
-        hotkeys.unbind("Escape");
-        hotkeys.unbind("Ctrl+C");
-        hotkeys.unbind("Ctrl+V");
+        hotkeys.unbind('Escape');
+        hotkeys.unbind('Cmd+C', 'Ctrl+C');
+        hotkeys.unbind('Cmd+V', 'Ctrl+V');
     });
 
     activate();

--- a/src/diagrams/diagram.js
+++ b/src/diagrams/diagram.js
@@ -2,7 +2,7 @@
 
 var _ = require('lodash');
 
-function diagram($scope, $location, $routeParams, $timeout, dialogs, common, datacontext, threatengine, diagramming, threatmodellocator) {
+function diagram($scope, $document, $location, $routeParams, $timeout, dialogs, common, datacontext, threatengine, diagramming, threatmodellocator, hotkeys) {
 
     // Using 'Controller As' syntax, so we assign this to the vm variable (for viewmodel).
     /*jshint validthis: true */
@@ -37,6 +37,7 @@ function diagram($scope, $location, $routeParams, $timeout, dialogs, common, dat
     vm.setGrid = setGrid;
     vm.showGrid = false;
     vm.selected = null;
+    vm.copied = null;
     vm.viewStencil = true;
     vm.viewThreats = false;
     vm.stencils = getStencils();
@@ -56,6 +57,10 @@ function diagram($scope, $location, $routeParams, $timeout, dialogs, common, dat
     vm.currentZoomLevel = 0;
     vm.maxZoom = 4;
 
+    hotkeys("Escape", escapeHotkey);
+    hotkeys("Ctrl+C", copyHotkey);
+    hotkeys("Ctrl+V", pasteHotkey);
+
     //structured exit
     $scope.$on('$locationChangeStart', function (event, current, previous) {
         //suppress structured exit when only search changes
@@ -70,6 +75,13 @@ function diagram($scope, $location, $routeParams, $timeout, dialogs, common, dat
     //element select
     $scope.$on('$locationChangeSuccess', function (event, current, previous) {
         onSelectElement();
+    });
+
+
+    $scope.$on('$destroy', function () {
+        hotkeys.unbind("Escape");
+        hotkeys.unbind("Ctrl+C");
+        hotkeys.unbind("Ctrl+V");
     });
 
     activate();
@@ -398,6 +410,32 @@ function diagram($scope, $location, $routeParams, $timeout, dialogs, common, dat
         if (threatWatchers[element.id]) {
             threatWatchers[element.id]();
             threatWatchers.splice(element.id, 1);
+        }
+    }
+
+    function escapeHotkey(event, handler) {
+        // if the current diagram is active
+        if (vm.currentDiagram.el === $document[0].activeElement) {
+            select(null);
+        }
+    }
+
+    function copyHotkey(event, handler) {
+        // if the current diagram is active
+        if (vm.currentDiagram.el === $document[0].activeElement) {
+            if (vm.selected) {
+                vm.copied = vm.selected;
+            }
+        }
+    }
+
+    function pasteHotkey(event, handler) {
+        // if the current diagram is active
+        if (vm.currentDiagram.el === $document[0].activeElement) {
+            if (vm.copied) {
+                vm.select(vm.copied);
+                vm.duplicateElement();
+            }
         }
     }
 }

--- a/src/diagrams/index.js
+++ b/src/diagrams/index.js
@@ -9,5 +9,4 @@ core.directive('tmtDiagram', ['common', 'diagramming', diagramdirectives.diagram
 core.directive('tmtModalClose', [elementPropertyDirectives.modalClose]);
 core.directive('tmtElementProperties', [elementPropertyDirectives.elementProperties]);
 core.directive('tmtElementThreats', ['$routeParams', '$location', 'common', 'dialogs', elementPropertyDirectives.elementThreats]);
-core.controller('diagram', ['$scope', '$location', '$routeParams', '$timeout', 'dialogs', 'common', 'datacontext', 'threatengine', 'diagramming', 'threatmodellocator', diagram]);
-
+core.controller('diagram', ['$scope', '$document', '$location', '$routeParams', '$timeout', 'dialogs', 'common', 'datacontext', 'threatengine', 'diagramming', 'threatmodellocator', 'hotkeys', diagram]);

--- a/src/services/diagramming.js
+++ b/src/services/diagramming.js
@@ -113,6 +113,11 @@ function diagramming() {
             interactive: interactive
         });
 
+        paper.el.setAttribute('tabindex', '0');
+        paper.el.addEventListener('mousedown', function() {
+            this.focus();
+        });
+
         target.appendChild(paper.el);
 
         return paper;

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -6,3 +6,4 @@ core.controller('structuredExitController', ['$scope', '$uibModalInstance', '$lo
 core.controller('confirmController', ['$scope', '$uibModalInstance', 'ok', 'cancel', 'parameter', require('./dialogControllers').confirmController]);
 core.factory('dialogs', ['$location', '$uibModal', require('./dialogs')]);
 core.factory('diagramming', [require('./diagramming')]);
+core.value('hotkeys', require('hotkeys-js'));


### PR DESCRIPTION
This is my first PR against the Threat Dragon codebase. Depending on circumstances, I may or may not be able to really hero this PR through the entire review process, but I found it to be valuable to open a PR anyway. Feel free to take inspiration from the changes if you find it best to do so.

I added hotkeys to the diagram to unselect the currently selected cell and to copy and paste a selected cell. The hotkey logic leverages the already existing functionality to do so.

I did not update tests, but they still pass. I had trouble getting the hotkeys object to inject into `diagram-spec.js`, and I'm starting to hit the limit of my timebox, so I felt it most appropriate to throw up a PR rather than let my work die without chance.

Functional changes:
- Pressing Escape while focused on the diagram will unselect the currently selected cell
- Pressing Ctrl-C while focused on the diagram will create a reference to the currenly selected cell
- Pressing Ctrl+V while focused on the diagram will duplicate the copied element

Nonfunctional changes:
- In diagramming.js, make created paper focus on mousedown and add a tabindex of 0 (in order to focus). Also add some css to ignore the outline on focus.
- Added hotkey.js to package.json, and pass in hotkey as a service in /services/index.js
- Added *.iml to .gitignore